### PR TITLE
Add CMake project to install configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(dav-sdk
+    LANGUAGES NONE
+    DESCRIPTION "spack configs for the dav sdk"
+    HOMEPAGE_URL dav-sdk.github.io)
+
+install(FILES spack/configs/packages.yaml DESTINATION spack/configs/davsdk)
+install(DIRECTORY spack/configs/template DESTINATION spack/environments/davsdk)
+install(DIRECTORY spack/configs/frontier DESTINATION spack/environments/davsdk)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ spack:
   # These specify the constraints defined by the DAV SDK
   - $spack/../davsdk/spack/configs/packages.yaml
 
- specs:
+  specs:
   # I/O
   - adios2
   - parallel-netcdf

--- a/spack/configs/template/spack.yaml
+++ b/spack/configs/template/spack.yaml
@@ -3,7 +3,7 @@
 # This file may not be copied, modified, or distributed
 # except according to those terms.
 #
-# A template rnvironment configuration file for the Data and Vis SDK
+# A template environment configuration file for the Data and Vis SDK
 #   maintainer: Ryan Krattiger @kwryankrattiger (ryan.krattiger@kitware.com)
 spack:
   concretizer:
@@ -14,7 +14,7 @@ spack:
   # These specify the constraints defined by the DAV SDK
   - $spack/../davsdk/spack/configs/packages.yaml
 
- specs:
+  specs:
   # I/O
   - adios2
   - parallel-netcdf


### PR DESCRIPTION
Adds a basic `CMakeLists.txt` to allow installation of dav sdk configs, fix some typos in template config.