### PR TITLE
Add submission to cdash in submit step

### DIFF
--- a/.gitlab/gitlab-ci-frontier.yml
+++ b/.gitlab/gitlab-ci-frontier.yml
@@ -9,6 +9,7 @@ stages:
   - pre
   - setup
   - install
+  - submit
   - post
 
 .checkout_commit: &checkout_commit |
@@ -38,6 +39,7 @@ stages:
     SPACK_BUILD_DIR: "${CUSTOM_CI_BUILDS_DIR}/artifacts/spack-build-${CI_PIPELINE_IID}"
     SPACK_USER_CACHE_PATH: "${SPACK_BUILD_DIR}/cache"
     SPACK_BUILDCACHE_DIR: "/lustre/orion/world-shared/ums032/frontier-buildcache/"
+    SPACK_PACKAGES_VERSION: "171dc3306e6915c1ce855dbda72498b2e1cff9cb"
 
     # Order matters
     JOB_MODULES: >-
@@ -58,7 +60,7 @@ setup:frontier-gcc:
     - *load_modules
   script:
     - source scripts/ci/gitlab-ci/setup-vars.sh
-    - bash scripts/ci/gitlab-ci/run.sh -p develop setup
+    - bash scripts/ci/gitlab-ci/run.sh -p "${SPACK_PACKAGES_VERSION}" setup
 
 install:frontier-gcc:
   extends: .frontier-common
@@ -78,10 +80,8 @@ install:frontier-gcc:
     - rsync -av "${SPACK_BUILD_DIR}/facility-config" "${SPACK_BUILD_COMPUTING_DIR}"
     - rsync -av "${SPACK_USER_CACHE_PATH}/" "${SPACK_USER_CACHE_COMPUTING_PATH}"
     - SPACK_BUILD_DIR="${SPACK_BUILD_COMPUTING_DIR}" SPACK_USER_CACHE_PATH="${SPACK_USER_CACHE_COMPUTING_PATH}" bash scripts/ci/gitlab-ci/run.sh install
-  after_script:
-    - *load_modules
-    - source scripts/ci/gitlab-ci/setup-vars.sh
-    - bash scripts/ci/gitlab-ci/run.sh submit
+    - rsync -av "${SPACK_USER_CACHE_COMPUTING_PATH}/" "${SPACK_USER_CACHE_PATH}"
+
   needs:
     - setup:frontier-gcc
   dependencies:
@@ -90,6 +90,19 @@ install:frontier-gcc:
   artifacts:
     paths:
       - spack_log.out
+
+submit:frontier-gcc:
+  extends: .frontier-common
+  stage: submit
+  tags: [shell]
+  before_script:
+    - *checkout_commit
+    - *load_modules
+  script:
+    - source scripts/ci/gitlab-ci/setup-vars.sh
+    - bash scripts/ci/gitlab-ci/run.sh submit
+  needs:
+    - install:frontier-gcc
 
 .report-status:
   tags: [shell]

--- a/scripts/ci/gitlab-ci/cdash-upload.patch
+++ b/scripts/ci/gitlab-ci/cdash-upload.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/spack/spack/reporters/cdash.py b/lib/spack/spack/reporters/cdash.py
+index cd3ac31a37..c9ae4949fa 100644
+--- a/lib/spack/spack/reporters/cdash.py
++++ b/lib/spack/spack/reporters/cdash.py
+@@ -296,7 +296,7 @@ def build_report(self, report_dir, specs):
+         # Generate reports for each package in each spec.
+         for spec in specs:
+             duration = 0
+-            if "time" in spec:
++            if "time" in spec and spec["time"]:
+                 duration = int(spec["time"])
+             for package in spec["packages"]:
+                 self.build_report_for_package(report_dir, package, duration)
+@@ -432,6 +432,9 @@ def upload(self, filename):
+             print("Cannot upload {0} due to missing upload url".format(filename))
+             return
+ 
++        if self.cdash_upload_url == "skip_upload":
++            return
++
+         # Compute md5 checksum for the contents of this file.
+         md5sum = checksum(hashlib.md5, filename, block_size=8192)
+ 

--- a/scripts/ci/gitlab-ci/run.sh
+++ b/scripts/ci/gitlab-ci/run.sh
@@ -49,6 +49,12 @@ case ${STEP} in
     echo "**********Setup Begin**********"
     git clone -c feature.manyFiles=true https://github.com/spack/spack.git "${SPACK_BUILD_DIR}/spack"
 
+    # Apply patch to be able to skip the cdash upload during spack install
+    patch="$(pwd)/scripts/ci/gitlab-ci/cdash-upload.patch"
+    cd "${SPACK_BUILD_DIR}/spack"
+    git apply "$patch"
+    cd -
+
     # Clone spack-packages
     mkdir -p "${SPACK_BUILD_DIR}/spack-packages"
     cd "${SPACK_BUILD_DIR}/spack-packages"
@@ -107,7 +113,13 @@ case ${STEP} in
     spack config blame
 
     # Install the environment with timing and parallel jobs
-    spack -t install "-j$((NUM_CORES*2))" --show-log-on-error --no-check-signature --fail-fast | tee spack_log.out 2>&1
+    spack -t install \
+      "-j$((NUM_CORES*2))" \
+      --show-log-on-error \
+      --no-check-signature \
+      --fail-fast \
+      "--cdash-upload-url=skip_upload" \
+      | tee spack_log.out 2>&1
 
     # Show what was installed
     spack find -lv
@@ -116,8 +128,9 @@ case ${STEP} in
 
   submit)
     echo "**********Submit Begin**********"
-    # Placeholder for submission to CDash or other reporting systems
-    echo "Submit step - currently a placeholder"
+
+    find "${SPACK_USER_CACHE_PATH}"/reports -type f -exec curl -T {} "https://open.cdash.org/submit.php?project=DAV-SDK" ';'
+
     echo "**********Submit End**********"
     ;;
 


### PR DESCRIPTION
Patches spack to be able to generate cdash reports without uploading during `spack install`, uploads all the reports in the submit step instead.